### PR TITLE
implicit selection of dialogue graph

### DIFF
--- a/Samples/ScriptableObject.meta
+++ b/Samples/ScriptableObject.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68ea37d8c0dac4844b31b76ec4c53b06
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples/ScriptableObject/DemoDialogue.asset
+++ b/Samples/ScriptableObject/DemoDialogue.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78b3fd9154634ebdb8c8a48960b9a16a, type: 3}
+  m_Name: DemoDialogue
+  m_EditorClassIdentifier: 
+  NodeLinks:
+  - BaseNodeGUID: 9486b70f-454f-4f89-87ff-2c40ab5693a2
+    PortName: Next
+    TargetNodeGUID: 950d1f90-0012-49cd-aeab-334f6d38f063
+  - BaseNodeGUID: 950d1f90-0012-49cd-aeab-334f6d38f063
+    PortName: Option 1
+    TargetNodeGUID: 65023dd8-950a-47ac-b9c3-49f2501a74be
+  - BaseNodeGUID: 950d1f90-0012-49cd-aeab-334f6d38f063
+    PortName: Option 2
+    TargetNodeGUID: 53eaef3e-61d3-484a-8a67-c59991fd6a8e
+  DialogueNodeData:
+  - NodeGUID: 950d1f90-0012-49cd-aeab-334f6d38f063
+    DialogueText: Test
+    Position: {x: 247, y: 191}
+  - NodeGUID: 65023dd8-950a-47ac-b9c3-49f2501a74be
+    DialogueText: 1
+    Position: {x: 493, y: 145}
+  - NodeGUID: 53eaef3e-61d3-484a-8a67-c59991fd6a8e
+    DialogueText: 2
+    Position: {x: 481, y: 266}

--- a/Samples/ScriptableObject/DemoDialogue.asset.meta
+++ b/Samples/ScriptableObject/DemoDialogue.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: f54d1bd14bd3ca042bd867b519fee8cc
-folderAsset: yes
-DefaultImporter:
+guid: 674dc93a24e86f445b19fe5ddc5c74ea
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/com.subtegral.dialoguesystem/Editor/GraphSaveUtility.cs
+++ b/com.subtegral.dialoguesystem/Editor/GraphSaveUtility.cs
@@ -28,7 +28,7 @@ namespace Subtegral.DialogueSystem.Editor
             };
         }
 
-        public void SaveNodes(string fileName)
+        public void SaveNodes(string filePath)
         {
             if (!Edges.Any()) return;
             var dialogueContainerObject = ScriptableObject.CreateInstance<DialogueContainer>();
@@ -55,17 +55,13 @@ namespace Subtegral.DialogueSystem.Editor
                     Position = node.GetPosition().position
                 });
             }
-
-            if (!AssetDatabase.IsValidFolder("Assets/Resources"))
-                AssetDatabase.CreateFolder("Assets", "Resources");
-
-            AssetDatabase.CreateAsset(dialogueContainerObject, $"Assets/Resources/{fileName}.asset");
+            AssetDatabase.CreateAsset(dialogueContainerObject, filePath);
             AssetDatabase.SaveAssets();
         }
 
-        public void LoadNarrative(string fileName)
+        public void LoadNarrative(string filePath)
         {
-            _dialogueContainer = Resources.Load<DialogueContainer>(fileName);
+            _dialogueContainer = AssetDatabase.LoadAssetAtPath<DialogueContainer>(filePath);
             if (_dialogueContainer == null)
             {
                 EditorUtility.DisplayDialog("File Not Found", "Target Narrative Data does not exist!", "OK");
@@ -118,7 +114,7 @@ namespace Subtegral.DialogueSystem.Editor
                 {
                     var targetNodeGUID = connections[j].TargetNodeGUID;
                     var targetNode = Nodes.First(x => x.GUID == targetNodeGUID);
-                    LinkNodesTogether(Nodes[i].outputContainer[j].Q<Port>(), (Port) targetNode.inputContainer[0]);
+                    LinkNodesTogether(Nodes[i].outputContainer[j].Q<Port>(), (Port)targetNode.inputContainer[0]);
 
                     targetNode.SetPosition(new Rect(
                         _dialogueContainer.DialogueNodeData.First(x => x.NodeGUID == targetNodeGUID).Position,


### PR DESCRIPTION
Hello,

I thought the save/load process might benefit some improvements, such as being closer to the one of the "Animation" Window, so this pull request does a few tweaks to the loading/saving process.

quick changelog:
- The "Narrative graph" load the selected asset graph from project selection
- The title changes to reflect current selection to avoid doubt on which file is selected
  - this idea is from major code editors, where we could also add an asterisk `*` if there's modifications to be saved.
  - modifying title is not very unity-esque so I'm less sure now...
- no "Load" anymore
- "save" and "new" dialogue file process reworked to use unity file selector